### PR TITLE
Update readme.md to account for Tahoe permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ Download [the latest binary built by GitHub actions](https://github.com/lynaghk/
 
     curl -LO https://github.com/lynaghk/vibe/releases/download/latest/vibe-macos-arm64.zip
     unzip vibe-macos-arm64.zip
+    ./vibe # this will self-sign the binary, download the image, and launch the VM
     sudo mv vibe /usr/local/bin
 
 If you use [mise-en-place](https://mise.jdx.dev/):


### PR DESCRIPTION
Suggest running the binary before moving it to somewhere more privileged like /usr/local/bin.

There's probably a more elegant way to do this, but this works at least.

Fixes #1 