### PR TITLE
Autogenerate .gitignore in .vibe folder to prevent tracking the disk image

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ const START_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_EXPECT_TIMEOUT: Duration = Duration::from_secs(30);
 const LOGIN_EXPECT_TIMEOUT: Duration = Duration::from_secs(120);
 const PROVISION_SCRIPT: &str = include_str!("provision.sh");
+const VIBE_GITIGNORE: &str = "# created by vibe automatically\n*\n";
 
 #[derive(Clone)]
 enum LoginAction {
@@ -611,7 +612,9 @@ fn ensure_instance_disk(
     }
 
     println!("Creating instance disk from {}...", template_raw.display());
-    std::fs::create_dir_all(instance_raw.parent().unwrap())?;
+    let instance_dir = instance_raw.parent().unwrap();
+    std::fs::create_dir_all(instance_dir)?;
+    fs::write(instance_dir.join(".gitignore"), VIBE_GITIGNORE)?;
     fs::copy(template_raw, instance_raw)?;
     Ok(())
 }


### PR DESCRIPTION
This change automates the creation of a .gitignore file inside the .vibe directory during the initial setup of a project's virtual machine.

  I have modified the `ensure_instance_disk` function to handle this automatically:
   * Automatic Setup: When a project is initialized for the first time, Vibe now creates the .vibe directory and immediately writes a .gitignore file into it. The generated .gitignore contains a wildcard (*), which tells Git to ignore everything inside the .vibe folder.
   * Constant Declaration: Added a VIBE_GITIGNORE constant to the top of src/main.rs to keep the content centralized and easy to modify.