### PR TITLE
Create a symlink to map the users home directory to `/root`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,18 @@ Options
             " if [ -f /root/.gemini/tmp/bin/rg ] && [ -f /usr/bin/rg ]; then mount --bind /usr/bin/rg /root/.gemini/tmp/bin/rg; fi"
                 .to_string()
         ));
+
+        // Symlink the host home directory path to /root so that absolute paths baked
+        // into plugin/tool configs (e.g. ~/.claude/plugins/installed_plugins.json) resolve
+        // correctly inside the VM without needing to rewrite any config files.
+        login_actions.push(Send(format!(
+            " mkdir -p {parent} && ln -sfn /root {home}",
+            parent = home
+                .parent()
+                .map(|p| p.to_string_lossy())
+                .unwrap_or("/".into()),
+            home = home.to_string_lossy(),
+        )));
     }
 
     for spec in &args.mounts {


### PR DESCRIPTION
I ran into the issue that claude plugins that were installed on the "home" system were not correctly loaded inside the VM. That is because the paths stored in the `root/.claude/plugins/installed_plugins.json` file would include a path like `/Users/{username}/.claude/plugins/...`.

It is also not possible to install any plugins from inside of the VM because claude is already expecting the users home directory to be present somewhere and then gets into directory trouble.

Creating a symlink from `/Users/username -> /root` fixes that issue for plugins that are installed  e.g. for a user or a project before booting up the VM. This also allows for installing plugins from inside of the VM. These plugins seem to be loaded correctly (at least the claude `/plugin` command says so).

The caveat is that, in the `/Users/{username}/.claude/plugins/installed_plugins.json` file, they are now listed as installed under `/root/.claude/...`. They seem to be loaded correctly anyways, no matter if using the VM or not, but there are at least issues when trying to delete a plugin. These issues only seem to show up when the plugin was installed for the project. For some reason, globally installed plugins can always be deleted. I don't really understand why and I would've expected different behavior (plugins installed from inside the VM cannot be uninstalled from outside of it).

I am not familiar with the plugin systems of the other agents whose directories are also mounted. I don't think creating the symlink inside of the VM to `/root` should pose any added security risks. Maybe opening this PR is a good start for some more discussion around this if desired. 😅 

The code in this PR was created using Claude Code and reviewed and somewhat extensively tested by me. The text of this PR was also written by me.