### PR TITLE
Add the Pi agent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Host                                      Guest                    Mode
 /Users/dev/.codex                         /root/.codex             read-write
 /Users/dev/.claude                        /root/.claude            read-write
 /Users/dev/.gemini                        /root/.gemini            read-write
+/Users/dev/.pi                            /root/.pi                read-write
 
 root@vibe:~/my-project#
 ```
@@ -112,6 +113,7 @@ Invoking vibe without a disk image:
 - shares the `~/.codex` directory with the VM, so you can use OpenAI's [codex](https://openai.com/codex/)
 - shares the `~/.claude` directory with the VM, so you can use Anthropic's [claude](https://claude.com/product/claude-code)
 - shares the `~/.gemini` directory with the VM, so you can use Google's [gemini-cli](https://github.com/google-gemini/gemini-cli)
+- shares the `~/.pi` directory with the VM, so you can use the [Pi agent harness](https://pi.dev/)
 
 The first time you run `vibe`, a Debian Linux image is downloaded to `~/.cache/vibe/`, configured with basic tools like gcc, [mise-en-place](https://mise.jdx.dev/), ripgrep, rust, etc., and saved as `default.raw`.
 (See [provision.sh](/src/provision.sh) for details.)

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ Options
             DirectoryShare::new(home.join(".codex"), "/root/.codex".into(), false),
             DirectoryShare::new(home.join(".claude"), "/root/.claude".into(), false),
             DirectoryShare::new(home.join(".gemini"), "/root/.gemini".into(), false),
+            DirectoryShare::new(home.join(".pi"), "/root/.pi".into(), false),
         ]
         .into_iter()
         .flatten()

--- a/src/provision.sh
+++ b/src/provision.sh
@@ -81,6 +81,7 @@ cat > .config/mise/config.toml <<MISE
     "npm:@openai/codex" = "latest"
     "npm:@anthropic-ai/claude-code" = "latest"
     "npm:@google/gemini-cli" = "latest"
+    "npm:@mariozechner/pi-coding-agent" = "latest"
 MISE
 
 touch .config/mise/mise.lock


### PR DESCRIPTION
Hi,

I would like to add the [Pi Agent](https://pi.dev/). 

I didn't manage to test the changes locally completely, as I was getting a `No such file or directory` error for `config.h.in`.

Nevertheless, I tested the `provision.sh` script in a Debian VM, and everything worked as expected with the disk partitioning and filesystem resize commands disabled.