### PR TITLE
Replace the depreacted Pi package

### DIFF
--- a/src/provision.sh
+++ b/src/provision.sh
@@ -81,7 +81,7 @@ cat > .config/mise/config.toml <<MISE
     "npm:@openai/codex" = "latest"
     "npm:@anthropic-ai/claude-code" = "latest"
     "npm:@google/gemini-cli" = "latest"
-    "npm:@mariozechner/pi-coding-agent" = "latest"
+    "npm:@earendil-works/pi-coding-agent" = "latest"
 MISE
 
 touch .config/mise/mise.lock


### PR DESCRIPTION
[Pi just yesterday moved](https://pi.dev/news/2026/5/7/pi-has-a-new-home) both their repository on GitHub and npm package name. The current packages still work but send out a lot of deprecation warnings when starting a new vibe VM.

This PR changes the name to the correct one. I've tested the changes locally, and everything seems to be in order with no deprecation warnings. Hopefully they won't change the name again after this PR gets merged 😅 