### PR TITLE
Fix claude code installation

### DIFF
--- a/provisioning/claude.sh
+++ b/provisioning/claude.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # Set this env var so claude doesn't complain about running as root.
 echo "export IS_SANDBOX=1" >> .bashrc
 
-tool='    "npm:@anthropic-ai/claude-code" = { version = "latest", npm-args = "--ignore-scripts=false" }'
+tool='    "npm:@anthropic-ai/claude-code" = { version = "latest", npm_args = "--ignore-scripts=false" }'
 echo "$tool" >> .config/mise/config.toml
 
 mise install


### PR DESCRIPTION
Fixed the typo, `npm_args` instead of `npm-args`

I somehow must've introduced a typo when opening the original PR. (https://github.com/lynaghk/vibe/pull/37) Sorry about that!

To double check, here is the documentation: https://mise.jdx.dev/dev-tools/backends/npm.html#npm-args